### PR TITLE
🔧 Increase cache TTL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     remotePatterns: [{ hostname: "via.placeholder.com" }],
+    minimumCacheTTL: 15552000,
   },
 }
 


### PR DESCRIPTION
This reduce the number of requests to the server for fetching images and fixes some glitches with the image rendering, caused by a bug of Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1192137.